### PR TITLE
Auto pause/resume & auto leave channel

### DIFF
--- a/src/main/java/com/robothand/highqualitybot/command/PauseCommand.java
+++ b/src/main/java/com/robothand/highqualitybot/command/PauseCommand.java
@@ -37,8 +37,12 @@ public class PauseCommand extends Command {
         if (musicPlayer.isPaused()) {
             channel.sendMessage("The player is already paused!").queue();
         } else {
-            musicPlayer.setPaused(true);
-            channel.sendMessage("Player paused!").queue();
+            if (musicPlayer.getPlayingTrack() == null) {
+                channel.sendMessage("There's nothing in the queue to pause!").queue();
+            } else {
+                musicPlayer.setPaused(true);
+                channel.sendMessage("Player paused!").queue();
+            }
         }
     }
 }

--- a/src/main/java/com/robothand/highqualitybot/command/PlayCommand.java
+++ b/src/main/java/com/robothand/highqualitybot/command/PlayCommand.java
@@ -38,6 +38,12 @@ public class PlayCommand extends Command {
         // Get player for this guild
         musicPlayer = GuildMusicPlayer.getPlayer(guild);
 
+        // don't do anything if there's nothing in the queue
+        if (musicPlayer.getPlayingTrack() == null && args.length < 2) {
+            channel.sendMessage("There's nothing in the queue to resume!").queue();
+            return;
+        }
+
         // Auto-join channel if player is not already in one
         if (!musicPlayer.isInChannel()) {
             VoiceChannel voice;
@@ -61,8 +67,8 @@ public class PlayCommand extends Command {
             musicPlayer.playTrack(search, channel);
         } else {
             if (musicPlayer.isPaused()) {
-                musicPlayer.setPaused(false);
-                channel.sendMessage("Player resumed.").queue();
+                    musicPlayer.setPaused(false);
+                    channel.sendMessage("Player resumed.").queue();
             } else {
                 channel.sendMessage("The player is already running!").queue();
             }

--- a/src/main/java/com/robothand/highqualitybot/music/GuildMusicPlayer.java
+++ b/src/main/java/com/robothand/highqualitybot/music/GuildMusicPlayer.java
@@ -56,6 +56,7 @@ public class GuildMusicPlayer {
         this.guild = guild;
 
         player.addListener(scheduler);
+        player.setPaused(true);
         GuildMusicPlayer.addPlayer(guild.getId(), this);
     }
 

--- a/src/main/java/com/robothand/highqualitybot/music/GuildMusicPlayer.java
+++ b/src/main/java/com/robothand/highqualitybot/music/GuildMusicPlayer.java
@@ -52,7 +52,7 @@ public class GuildMusicPlayer {
     public GuildMusicPlayer(Guild guild) {
         player = playerManager.createPlayer();
         handler = new AudioPlayerSendHandler(player);
-        scheduler = new TrackScheduler(player);
+        scheduler = new TrackScheduler(player, this);
         this.guild = guild;
 
         player.addListener(scheduler);

--- a/src/main/java/com/robothand/highqualitybot/music/GuildMusicPlayer.java
+++ b/src/main/java/com/robothand/highqualitybot/music/GuildMusicPlayer.java
@@ -140,7 +140,7 @@ public class GuildMusicPlayer {
             public void noMatches() {
                 if (channel != null) {
                     String message = "Could not find any matches for \"" + search + "\"";
-                    channel.sendMessage(message);
+                    channel.sendMessage(message).queue();
                 }
             }
 

--- a/src/main/java/com/robothand/highqualitybot/music/TrackScheduler.java
+++ b/src/main/java/com/robothand/highqualitybot/music/TrackScheduler.java
@@ -19,11 +19,13 @@ public class TrackScheduler extends AudioEventAdapter {
     private Repeat repeating;
     private final Queue<AudioTrack> queue;
     private final AudioPlayer player;
+    private final GuildMusicPlayer guildPlayer;
     private AudioTrack prevTrack;
 
-    public TrackScheduler(AudioPlayer player) {
+    public TrackScheduler(AudioPlayer player, GuildMusicPlayer guildPlayer) {
         repeating = Repeat.OFF;
         this.player = player;
+        this.guildPlayer = guildPlayer;
         queue = new LinkedList<>();
     }
 
@@ -55,6 +57,7 @@ public class TrackScheduler extends AudioEventAdapter {
 
         if (player.getPlayingTrack() == null) {
             player.setPaused(true);
+            guildPlayer.leaveChannel();
         }
     }
 

--- a/src/main/java/com/robothand/highqualitybot/music/TrackScheduler.java
+++ b/src/main/java/com/robothand/highqualitybot/music/TrackScheduler.java
@@ -28,7 +28,9 @@ public class TrackScheduler extends AudioEventAdapter {
     }
 
     public void add(AudioTrack track) {
-        if (!player.startTrack(track, true)) {
+        if (player.startTrack(track, true)) {
+            player.setPaused(false);
+        } else {
             queue.offer(track);
         }
     }
@@ -49,6 +51,10 @@ public class TrackScheduler extends AudioEventAdapter {
         } else if (repeating == Repeat.ALL) {
             queue.add(player.getPlayingTrack());
             player.startTrack(queue.poll(), false);
+        }
+
+        if (player.getPlayingTrack() == null) {
+            player.setPaused(true);
         }
     }
 


### PR DESCRIPTION
Closes #3 by having the bot automatically leave the voice channel when the last song in the queue ends. Also automatically resumes and pauses the player when the first track is added to the queue and the last one ends, respectively. The pause and play commands are now barred from modifying the paused state while there is nothing in the queue.