### PR TITLE
nowplaying/queue Command Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 *.iml
 *.ipr
 *.iws
+
+# macos
+.DS_Store
+
+# config file
+config.txt

--- a/src/main/java/com/robothand/highqualitybot/command/NowPlayingCommand.java
+++ b/src/main/java/com/robothand/highqualitybot/command/NowPlayingCommand.java
@@ -2,6 +2,7 @@ package com.robothand.highqualitybot.command;
 
 import com.robothand.highqualitybot.Bot;
 import com.robothand.highqualitybot.music.GuildMusicPlayer;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.MessageChannel;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
@@ -29,12 +30,19 @@ public class NowPlayingCommand extends Command {
     @Override
     public void onCommand(MessageReceivedEvent event, String[] args) {
         GuildMusicPlayer musicPlayer;
+        AudioTrack track;
         Guild guild = event.getGuild();
         MessageChannel channel = event.getChannel();
+        StringBuilder message = new StringBuilder();
 
         musicPlayer = GuildMusicPlayer.getPlayer(guild);
+        track = musicPlayer.getPlayingTrack();
 
-        String message = "Playing right now: " + musicPlayer.getPlayingTrack().getInfo().title;
-        channel.sendMessage(message).queue();
+        if (track == null) {
+            message.append("Nothing is playing right now.");
+        } else {
+            message.append("Playing right now: ").append(track.getInfo().title);
+        }
+        channel.sendMessage(message.toString()).queue();
     }
 }

--- a/src/main/java/com/robothand/highqualitybot/command/QueueCommand.java
+++ b/src/main/java/com/robothand/highqualitybot/command/QueueCommand.java
@@ -34,18 +34,26 @@ public class QueueCommand extends Command {
         GuildMusicPlayer musicPlayer;
         Guild guild = event.getGuild();
         MessageChannel channel = event.getChannel();
+        StringBuilder message = new StringBuilder();
 
         musicPlayer = GuildMusicPlayer.getPlayer(guild);
         Queue<AudioTrack> queue = musicPlayer.getQueue();
 
-        String message = "Current Queue:\n";
-        int currentTrack = 1;
+        if (queue.isEmpty()) {
+            message.append("The queue is empty!");
+        } else {
+            message.append("Current Queue (").append(queue.size()).append(" tracks):\n");
+            int currentTrack = 1;
 
-        for (AudioTrack track : queue) {
-            message = message.concat(currentTrack + ". " + track.getInfo().title + "\n");
-            currentTrack++;
+            for (AudioTrack track : queue) {
+                message.append(currentTrack + ". " + track.getInfo().title + "\n");
+
+                if (currentTrack++ > 10) {
+                    break;
+                }
+            }
         }
 
-        channel.sendMessage(message).queue();
+        channel.sendMessage(message.toString()).queue();
     }
 }


### PR DESCRIPTION
queue:

- prevent message character count from overflowing by only printing the first ten tracks in the queue (Closes #4)
- if the queue is empty, output a message stating such rather than just "Current Queue:" followed by no track names (Closes #10)

nowplaying:

- avoid trying to print out the name of the currently playing track when the player is inactive (Closes #10)