### PR TITLE
Prevent double help command output

### DIFF
--- a/src/main/java/com/robothand/highqualitybot/command/Commands.java
+++ b/src/main/java/com/robothand/highqualitybot/command/Commands.java
@@ -72,7 +72,7 @@ public class Commands extends ListenerAdapter {
     }
 
     // Get the entire Hashtable of Commands
-    public ArrayList<Command> getCommands() {
-        return new ArrayList<>(commands.values());
+    public Hashtable<String, Command> getCommands() {
+        return commands;
     }
 }

--- a/src/main/java/com/robothand/highqualitybot/command/HelpCommand.java
+++ b/src/main/java/com/robothand/highqualitybot/command/HelpCommand.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.core.entities.MessageChannel;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 
 import java.util.ArrayList;
+import java.util.Hashtable;
 
 /**
  * HelpCommand.java
@@ -47,17 +48,17 @@ public class HelpCommand extends Command {
 
     // Creates a formatted list of all commands
     private String genCommandList() {
-        ArrayList<Command> commands = Commands.getInstance().getCommands();
+        Hashtable<String, Command> commands = Commands.getInstance().getCommands();
 
         StringBuilder message = new StringBuilder();
         message.append("Available commands:\n");
 
-        // iterate over all commands
-        for (Command command : commands) {
-            String[] names = command.getNames();
+        // Iterate over all commands
+        for (String name: commands.keySet()) {
+            Command command = commands.get(name);
             String shortDesc = command.getShortDesc();
 
-            message.append("**").append(names[0]).append("** - ");
+            message.append("**").append(name).append("** - ");
             message.append((shortDesc != null) ? shortDesc : "Short description not available.").append("\n");
         }
 

--- a/src/main/java/com/robothand/highqualitybot/permission/PermissionManager.java
+++ b/src/main/java/com/robothand/highqualitybot/permission/PermissionManager.java
@@ -34,7 +34,7 @@ public class PermissionManager {
 
         for (String name : list.split(",")) {
             if (name.trim().equals("*")) {
-                commands = Commands.getInstance().getCommands();
+                commands = (ArrayList<Command>)(Commands.getInstance().getCommands().values());
                 break;
             }
 


### PR DESCRIPTION
Prevents the help command from listing commands multiple times. Closes #50 